### PR TITLE
configure for modules & skip type checking

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,8 +14,32 @@ export default [
   },
   // Base ESLint recommended rules
   js.configs.recommended,
+  // TypeScript config files (without type checking)
+  {
+    files: ['*.config.ts', '*.config.js'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...typescriptPlugin.configs.recommended.rules,
+      'prettier/prettier': 'error',
+    },
+  },
+  // Regular TypeScript files (with type checking)
   {
     files: ['*.ts', '*.tsx'],
+    ignores: ['*.config.ts'],
     languageOptions: {
       parser: typescriptParser,
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ruio",
   "version": "1.0.0",
+  "type": "module",
   "author": "Gary Rivera <a.gary.rivera@gmail.com> (https://github.com/gary-rivera)",
   "description": "A React developer tool for dynamically applying border styles to elements.",
   "private": false,


### PR DESCRIPTION
4s
Run npm run lint

> ruio@1.0.0 lint
> eslint "**/*.{js,jsx,ts,tsx}"

(node:2194) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///home/runner/work/ruio/ruio/eslint.config.js?mtime=1762473571393 is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /home/runner/work/ruio/ruio/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)

/home/runner/work/ruio/ruio/vitest.config.ts
  0:0  error  Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
The file was not found in any of the provided project(s): vitest.config.ts

✖ 1 problem (1 error, 0 warnings)
