### PR TITLE
chore: bump version to v1.0.1 - fix bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "author": "Gary Rivera <a.gary.rivera@gmail.com> (https://github.com/gary-rivera)",
   "description": "A React developer tool for dynamically applying border styles to elements.",


### PR DESCRIPTION
was 2.14mb due to docs. now its about 135kb