### PR TITLE
chore: normalize naming of element selection logic

### DIFF
--- a/src/components/ElementSelectionTooltip.tsx
+++ b/src/components/ElementSelectionTooltip.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { TooltipData } from '@hooks/useElementSelection'
+import { PickerTooltipData } from '@hooks/useElementPicker'
 import { Tooltip } from './Tooltip'
 import { TooltipContent } from './TooltipContent'
 
 interface ElementSelectionTooltipProps {
-  data: TooltipData | null
+  data: PickerTooltipData | null
 }
 
 /**
- * Tooltip that follows the cursor during element selection mode.
+ * Tooltip that follows the cursor during element picker mode.
  * Displays component name, depth, and selector information for debugging.
  */
 export const ElementSelectionTooltip: React.FC<ElementSelectionTooltipProps> = ({ data }) => {

--- a/src/components/PersistedElementTooltip.tsx
+++ b/src/components/PersistedElementTooltip.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState, useMemo } from 'react'
-import { TooltipData } from '@hooks/useElementSelection'
+import { PickerTooltipData } from '@hooks/useElementPicker'
 import { useTooltipPositioning } from '@hooks/useTooltipPositioning'
 import { useTooltipDrag } from '@hooks/useTooltipDrag'
 import { Tooltip } from './Tooltip'
 import { TooltipContent } from './TooltipContent'
 
 interface PersistedElementTooltipProps {
-  data: Omit<TooltipData, 'x' | 'y'> | null
+  data: Omit<PickerTooltipData, 'x' | 'y'> | null
   rootElement: HTMLElement | null
 }
 

--- a/src/components/RuioUIContainer.tsx
+++ b/src/components/RuioUIContainer.tsx
@@ -9,43 +9,43 @@ import { useRuioContext } from '@root/context/RuioContextProvider'
 
 import styles from '@components/RuioUIContainer.module.css'
 
-type UIPanelVisibility = { elementSelector: boolean; settingsModal: boolean }
+type UIPanelVisibility = { elementPicker: boolean; settingsModal: boolean }
 
 function RuioUIContainer(_: unknown, ref: React.Ref<HTMLDivElement>) {
   const {
     ruioEnabled,
-    isElementSelectionModeActive,
-    setIsElementSelectionModeActive,
+    isElementPickerActive,
+    setIsElementPickerActive,
     tooltipData,
     persistedTooltipData,
     rootElement,
   } = useRuioContext()
 
   const [panelVisibility, setPanelVisibility] = useState<UIPanelVisibility>({
-    elementSelector: false,
+    elementPicker: false,
     settingsModal: false,
   })
 
   const exclusivelyTogglePanel = (panel: keyof UIPanelVisibility) => {
     setPanelVisibility((prev) => {
-      const newState = { elementSelector: false, settingsModal: false, [panel]: !prev[panel] }
+      const newState = { elementPicker: false, settingsModal: false, [panel]: !prev[panel] }
       return newState
     })
 
-    // ensure element selection deactivated when opening settings
+    // ensure element picker deactivated when opening settings
     if (panel === 'settingsModal' && !panelVisibility.settingsModal) {
-      setIsElementSelectionModeActive(false)
+      setIsElementPickerActive(false)
     }
   }
 
-  const getIconStateClass = (icon: 'settings' | 'elementSelector') => {
+  const getIconStateClass = (icon: 'settings' | 'elementPicker') => {
     const baseClass = styles.iconContainer
 
     const thisIconIsActive =
-      icon === 'settings' ? panelVisibility.settingsModal : isElementSelectionModeActive
+      icon === 'settings' ? panelVisibility.settingsModal : isElementPickerActive
 
     const otherIconIsActive =
-      icon === 'settings' ? isElementSelectionModeActive : panelVisibility.settingsModal
+      icon === 'settings' ? isElementPickerActive : panelVisibility.settingsModal
 
     if (thisIconIsActive) return `${baseClass} ${styles.iconActive}`
     if (otherIconIsActive) return `${baseClass} ${styles.iconDimmed}`
@@ -71,15 +71,15 @@ function RuioUIContainer(_: unknown, ref: React.Ref<HTMLDivElement>) {
           )}
         </div>
 
-        <div id="ruio-element-select-container" className={getIconStateClass('elementSelector')}>
-          <ElementSelectIcon onClick={() => exclusivelyTogglePanel('elementSelector')} />
+        <div id="ruio-element-select-container" className={getIconStateClass('elementPicker')}>
+          <ElementSelectIcon onClick={() => exclusivelyTogglePanel('elementPicker')} />
         </div>
       </div>
 
-      <RuioToggleController isDimmed={isElementSelectionModeActive || panelVisibility.settingsModal} />
+      <RuioToggleController isDimmed={isElementPickerActive || panelVisibility.settingsModal} />
 
-      {isElementSelectionModeActive && <ElementSelectionTooltip data={tooltipData} />}
-      {!isElementSelectionModeActive && ruioEnabled && (
+      {isElementPickerActive && <ElementSelectionTooltip data={tooltipData} />}
+      {!isElementPickerActive && ruioEnabled && (
         <PersistedElementTooltip data={persistedTooltipData} rootElement={rootElement} />
       )}
     </div>

--- a/src/components/TooltipContent.tsx
+++ b/src/components/TooltipContent.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { TooltipData } from '@hooks/useElementSelection'
+import { PickerTooltipData } from '@hooks/useElementPicker'
 import styles from './Tooltip.module.css'
 
 interface TooltipContentProps {
-  data: Omit<TooltipData, 'x' | 'y'>
+  data: Omit<PickerTooltipData, 'x' | 'y'>
 }
 
 /**

--- a/src/components/icons/ElementSelectIcon.tsx
+++ b/src/components/icons/ElementSelectIcon.tsx
@@ -6,10 +6,10 @@ import styles from '@root/styles/icons.module.css'
 import ElementSelectSvg from '@assets/svg/ruio-element-select-icon.svg?react'
 
 function ElementSelectIcon({ onClick }: IconProps) {
-  const { toggleElementSelectionMode, ruioEnabled } = useRuioContext()
+  const { toggleElementPicker, ruioEnabled } = useRuioContext()
 
   function handleClick(event: MouseEvent<HTMLButtonElement>) {
-    toggleElementSelectionMode()
+    toggleElementPicker()
     onClick?.(event)
   }
 

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -27,7 +27,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     ruioEnabled,
     currentColorPalette,
     rootElement,
-    isElementSelectionModeActive,
+    isElementPickerActive,
     theme,
     setTheme,
   } = useRuioContext()
@@ -120,7 +120,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       depth,
       currentColorPalette,
       rootElement,
-      isElementSelectionModeActive,
+      isElementPickerActive,
     })
     window.open(issueUrl, '_blank', 'noopener,noreferrer')
   }

--- a/src/context/RuioContextProvider.tsx
+++ b/src/context/RuioContextProvider.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react'
 import { applyCommittedOutlines, calculateMaxDepth } from '@utils/outline'
 import { useLocalStorageState } from '@hooks/useLocalStorageState'
-import { useElementSelection, TooltipData } from '@hooks/useElementSelection'
+import { useElementPicker, PickerTooltipData } from '@hooks/useElementPicker'
 import { getElementInfo } from '@utils/elementInfo'
 import { detectRootElement } from '@utils/config'
 
@@ -24,9 +24,9 @@ interface RuioContextProps {
 
   rootElement: HTMLElement | null // the root element that is selected (defaults to div.body#root)
 
-  isElementSelectionModeActive: boolean // is element selection mode active -- aka are there hover and click events drilled into the DOM
-  setIsElementSelectionModeActive: React.Dispatch<React.SetStateAction<boolean>> // toggle element selection mode
-  toggleElementSelectionMode: () => void // cb to toggle element selection mode (for clarity, might remove)
+  isElementPickerActive: boolean // is element picker active -- aka are there hover and click events drilled into the DOM
+  setIsElementPickerActive: React.Dispatch<React.SetStateAction<boolean>> // toggle element picker
+  toggleElementPicker: () => void // cb to toggle element picker
 
   currentColorPalette: string // the key of the current color palette aka theme
   setCurrentColorPalette: React.Dispatch<React.SetStateAction<string>> // setter for the color palette theme
@@ -34,8 +34,8 @@ interface RuioContextProps {
   theme: 'light' | 'dark' // current UI theme
   setTheme: React.Dispatch<React.SetStateAction<'light' | 'dark'>> // setter for the theme
 
-  tooltipData: TooltipData | null // tooltip data for element selection mode
-  persistedTooltipData: Omit<TooltipData, 'x' | 'y'> | null // persisted tooltip data for selected root element
+  tooltipData: PickerTooltipData | null // tooltip data for element picker
+  persistedTooltipData: Omit<PickerTooltipData, 'x' | 'y'> | null // persisted tooltip data for selected root element
 }
 
 const RuioContext = createContext<RuioContextProps | undefined>(undefined)
@@ -60,9 +60,9 @@ export const RuioContextProvider = ({
   // local state fallback for SSR compatibility
   const [maxDepth, setMaxDepth] = useState(DEFAULT_MAX_DEPTH_WITHOUT_ROOT)
   const [rootElement, setRootElement] = useState<HTMLElement | null>(null)
-  const [persistedTooltipData, setPersistedTooltipData] = useState<Omit<TooltipData, 'x' | 'y'> | null>(
-    null,
-  )
+  const [persistedTooltipData, setPersistedTooltipData] = useState<
+    Omit<PickerTooltipData, 'x' | 'y'> | null
+  >(null)
 
   const depth = localStorageState.depth
   const setDepth = localStorageState.setDepth
@@ -97,7 +97,7 @@ export const RuioContextProvider = ({
     }
   }, [depth, maxDepth, setDepth])
 
-  const handleRootSelected = useCallback(
+  const handleRootPicked = useCallback(
     (element: HTMLElement) => {
       // Capture element info for persisted tooltip
       const elementInfo = getElementInfo(element)
@@ -107,7 +107,7 @@ export const RuioContextProvider = ({
       })
 
       // Set to null first, then to the element to force the useEffect to run
-      // This ensures outlines are always reapplied, even when selecting the same element
+      // This ensures outlines are always reapplied, even when picking the same element
       setRootElement(null)
       // Use setTimeout to ensure the null state is processed before setting the new element
       setTimeout(() => {
@@ -117,11 +117,11 @@ export const RuioContextProvider = ({
     [depth],
   )
 
-  const rootSelection = useElementSelection({
+  const elementPicker = useElementPicker({
     ruioEnabled: localStorageState.ruioEnabled,
     depth,
     currentColorPalette,
-    onElementSelected: handleRootSelected,
+    onElementPicked: handleRootPicked,
   })
 
   // apply theme to document root
@@ -146,14 +146,14 @@ export const RuioContextProvider = ({
       setDepth,
       maxDepth,
       rootElement,
-      isElementSelectionModeActive: rootSelection.isActive,
-      setIsElementSelectionModeActive: rootSelection.setIsActive,
-      toggleElementSelectionMode: rootSelection.toggle,
+      isElementPickerActive: elementPicker.isActive,
+      setIsElementPickerActive: elementPicker.setIsActive,
+      toggleElementPicker: elementPicker.toggle,
       currentColorPalette,
       setCurrentColorPalette,
       theme,
       setTheme,
-      tooltipData: rootSelection.tooltipData,
+      tooltipData: elementPicker.tooltipData,
       persistedTooltipData,
     }),
     [
@@ -163,14 +163,14 @@ export const RuioContextProvider = ({
       setDepth,
       maxDepth,
       rootElement,
-      rootSelection.isActive,
-      rootSelection.setIsActive,
-      rootSelection.toggle,
+      elementPicker.isActive,
+      elementPicker.setIsActive,
+      elementPicker.toggle,
       currentColorPalette,
       setCurrentColorPalette,
       theme,
       setTheme,
-      rootSelection.tooltipData,
+      elementPicker.tooltipData,
       persistedTooltipData,
     ],
   )

--- a/src/controllers/ElementPicker.tsx
+++ b/src/controllers/ElementPicker.tsx
@@ -3,6 +3,7 @@ import { setConfigValueAtKey, parseSelectorFromSelectedElement } from '@utils/co
 const DEFAULT_ROOT_ELEMENT = 'root'
 
 /**
+ * Interactive element picker that allows users to select DOM elements via hover and click.
  * Attaches hover and click listeners to elements under the specified root element.
  * When an element is hovered or clicked, the provided callback function is executed.
  *
@@ -11,7 +12,7 @@ const DEFAULT_ROOT_ELEMENT = 'root'
  * @param {function(): void} onMouseOut - Optional callback invoked when mouse leaves an element
  * @returns {function(): void} - A cleanup function that removes all attached event listeners.
  */
-export const ElementInteractionController = (
+export const ElementPicker = (
   onHover: (element: HTMLElement, x: number, y: number) => void,
   onClick: (element: HTMLElement) => void,
   onMouseOut?: () => void,
@@ -19,7 +20,7 @@ export const ElementInteractionController = (
   const rootElement = document.querySelector(`#${DEFAULT_ROOT_ELEMENT}`) as HTMLElement
   if (!rootElement) {
     console.error(
-      "[ruio][ElementInteractionController] Root element not found. Make sure your project's root element matches the DEFAULT_ROOT_ELEMENT: ",
+      "[ruio][ElementPicker] Root element not found. Make sure your project's root element matches the DEFAULT_ROOT_ELEMENT: ",
       DEFAULT_ROOT_ELEMENT,
     )
     // Return a no-op cleanup function to prevent undefined errors

--- a/src/controllers/RuioToggleController.tsx
+++ b/src/controllers/RuioToggleController.tsx
@@ -6,11 +6,11 @@ type RuioToggleControllerProps = {
 }
 
 function RuioToggleController({ isDimmed = false }: RuioToggleControllerProps) {
-  const { ruioEnabled, setRuioEnabled, setIsElementSelectionModeActive } = useRuioContext()
+  const { ruioEnabled, setRuioEnabled, setIsElementPickerActive } = useRuioContext()
 
   const handleToggle = () => {
     setRuioEnabled(!ruioEnabled)
-    setIsElementSelectionModeActive(false)
+    setIsElementPickerActive(false)
   }
 
   const getButtonClass = () => {

--- a/src/hooks/useElementPicker.ts
+++ b/src/hooks/useElementPicker.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
 import { applyPreviewOutlines, clearPreviewOutlines } from '@utils/outline'
-import { ElementInteractionController } from '@controllers/ElementInteractionController'
+import { ElementPicker } from '@controllers/ElementPicker'
 import { debounce } from '@utils/debounce'
 import { getElementInfo } from '@utils/elementInfo'
 
-export interface TooltipData {
+export interface PickerTooltipData {
   // React component info
   reactComponentName: string | null
   parentComponentName: string | null
@@ -27,32 +27,32 @@ export interface TooltipData {
   y: number
 }
 
-interface UseElementSelectionOptions {
+interface UseElementPickerOptions {
   ruioEnabled: boolean
   depth: number
   currentColorPalette: string
-  onElementSelected: (element: HTMLElement) => void
+  onElementPicked: (element: HTMLElement) => void
 }
 
-interface UseElementSelectionReturn {
+interface UseElementPickerReturn {
   isActive: boolean
   setIsActive: React.Dispatch<React.SetStateAction<boolean>>
   toggle: () => void
-  tooltipData: TooltipData | null
+  tooltipData: PickerTooltipData | null
 }
 
 /**
- * Custom hook for managing element selection mode.
- * Handles hover interactions, element selection, and cleanup of event listeners.
+ * Custom hook for managing element picker mode.
+ * Handles hover interactions, element picking, and cleanup of event listeners.
  */
-export const useElementSelection = ({
+export const useElementPicker = ({
   ruioEnabled,
   depth,
   currentColorPalette,
-  onElementSelected,
-}: UseElementSelectionOptions): UseElementSelectionReturn => {
+  onElementPicked,
+}: UseElementPickerOptions): UseElementPickerReturn => {
   const [isActive, setIsActive] = useState(false)
-  const [tooltipData, setTooltipData] = useState<TooltipData | null>(null)
+  const [tooltipData, setTooltipData] = useState<PickerTooltipData | null>(null)
 
   // Toggle function wrapped in useCallback to maintain referential equality
   const toggle = useCallback(() => {
@@ -76,36 +76,32 @@ export const useElementSelection = ({
       }, 50)
 
       const debouncedCommit = debounce((element: HTMLElement) => {
-        // Clear preview outlines when an element is selected
+        // Clear preview outlines when an element is picked
         clearPreviewOutlines()
         setTooltipData(null)
         setIsActive(false)
-        onElementSelected(element)
+        onElementPicked(element)
       }, 50)
 
       const handleMouseOut = () => {
         setTooltipData(null)
       }
 
-      const cleanupSelection = ElementInteractionController(
-        debouncedPreview,
-        debouncedCommit,
-        handleMouseOut,
-      )
+      const cleanupPicker = ElementPicker(debouncedPreview, debouncedCommit, handleMouseOut)
 
       return () => {
-        // Clear preview outlines when exiting selection mode
+        // Clear preview outlines when exiting picker mode
         clearPreviewOutlines()
         setTooltipData(null)
-        if (cleanupSelection) {
-          cleanupSelection()
+        if (cleanupPicker) {
+          cleanupPicker()
         }
       }
     } else {
-      // Clear tooltip when selection mode is disabled
+      // Clear tooltip when picker mode is disabled
       setTooltipData(null)
     }
-  }, [isActive, depth, ruioEnabled, currentColorPalette, onElementSelected])
+  }, [isActive, depth, ruioEnabled, currentColorPalette, onElementPicked])
 
   return { isActive, setIsActive, toggle, tooltipData }
 }

--- a/src/utils/githubIssue.ts
+++ b/src/utils/githubIssue.ts
@@ -5,7 +5,7 @@ export interface RuioState {
   depth: number
   currentColorPalette: string
   rootElement: HTMLElement | null
-  isElementSelectionModeActive: boolean
+  isElementPickerActive: boolean
 }
 
 /**
@@ -78,7 +78,7 @@ export const generateGitHubIssueUrl = (ruioState: RuioState): string => {
 - **Depth:** ${ruioState.depth}
 - **Color Palette:** ${ruioState.currentColorPalette}
 - **Root Element:** ${getRootElementInfo()}
-- **Element Selection Mode Active:** ${ruioState.isElementSelectionModeActive ? 'Yes' : 'No'}
+- **Element Picker Mode Active:** ${ruioState.isElementPickerActive ? 'Yes' : 'No'}
 
 `)
 

--- a/test/components/RuioUIContainer.test.tsx
+++ b/test/components/RuioUIContainer.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@controllers/RuioToggleController', () => ({
   ),
 }))
 
-// Mock applyCommittedOutlines and ElementInteractionController
+// Mock applyCommittedOutlines and ElementPicker
 vi.mock('@utils/outline', async () => {
   const actual = await vi.importActual<typeof import('@utils/outline')>('@utils/outline')
   return {
@@ -24,8 +24,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn(() => vi.fn()),
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn(() => vi.fn()),
 }))
 
 describe('RuioUIContainer - Icon Dimming', () => {

--- a/test/components/SettingsModal.test.tsx
+++ b/test/components/SettingsModal.test.tsx
@@ -17,8 +17,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn(() => vi.fn()),
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn(() => vi.fn()),
 }))
 
 describe('SettingsModal - Report Issue Feature', () => {
@@ -75,7 +75,7 @@ describe('SettingsModal - Report Issue Feature', () => {
         ruioEnabled: true,
         depth: expect.any(Number),
         currentColorPalette: expect.any(String),
-        isElementSelectionModeActive: expect.any(Boolean),
+        isElementPickerActive: expect.any(Boolean),
       }),
     )
 
@@ -104,7 +104,7 @@ describe('SettingsModal - Report Issue Feature', () => {
     expect(callArgs).toHaveProperty('depth')
     expect(callArgs).toHaveProperty('currentColorPalette')
     expect(callArgs).toHaveProperty('rootElement')
-    expect(callArgs).toHaveProperty('isElementSelectionModeActive')
+    expect(callArgs).toHaveProperty('isElementPickerActive')
   })
 
   test('generated URL contains environment information', () => {
@@ -113,7 +113,7 @@ describe('SettingsModal - Report Issue Feature', () => {
       depth: 5,
       currentColorPalette: 'dynamic',
       rootElement: null,
-      isElementSelectionModeActive: false,
+      isElementPickerActive: false,
     }
 
     const url = githubIssue.generateGitHubIssueUrl(testState)

--- a/test/context/RuioContextProvider.elementPicker.test.tsx
+++ b/test/context/RuioContextProvider.elementPicker.test.tsx
@@ -13,8 +13,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn((onHover, onClick) => {
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn((onHover, onClick) => {
     // Store callbacks for testing
     const controller = {
       onHover,
@@ -29,16 +29,16 @@ vi.mock('@controllers/ElementInteractionController', () => ({
 
 // Test component to access context and trigger element selection
 const ElementSelectionTester = () => {
-  const { rootElement, toggleElementSelectionMode, isElementSelectionModeActive, ruioEnabled, depth } =
+  const { rootElement, toggleElementPicker, isElementPickerActive, ruioEnabled, depth } =
     useRuioContext()
 
   return (
     <div>
       <div data-testid="root-element-id">{rootElement?.id || 'None'}</div>
-      <div data-testid="selection-mode-active">{isElementSelectionModeActive ? 'true' : 'false'}</div>
+      <div data-testid="selection-mode-active">{isElementPickerActive ? 'true' : 'false'}</div>
       <div data-testid="ruio-enabled">{ruioEnabled ? 'true' : 'false'}</div>
       <div data-testid="depth">{depth}</div>
-      <button onClick={toggleElementSelectionMode} data-testid="toggle-selection">
+      <button onClick={toggleElementPicker} data-testid="toggle-selection">
         Toggle Selection Mode
       </button>
     </div>
@@ -157,11 +157,11 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
     })
 
     // STEP 2: Simulate clicking on target element to make it the new root
-    // This would normally be done through ElementInteractionController
+    // This would normally be done through ElementPicker
     // We need to manually trigger the element selection since we're mocking
-    const { ElementInteractionController } = await import('@controllers/ElementInteractionController')
-    const lastCall = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const { ElementPicker } = await import('@controllers/ElementPicker')
+    const lastCall = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     const onClickCallback = lastCall?.[1]
 
@@ -222,8 +222,8 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
     })
 
     // STEP 5: Click on the SAME element again (target-element)
-    const lastCall2 = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const lastCall2 = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     const onClickCallback2 = lastCall2?.[1]
 
@@ -342,9 +342,9 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
     })
 
     // STEP 2: Simulate clicking on target element to make it the new root
-    const { ElementInteractionController } = await import('@controllers/ElementInteractionController')
-    const lastCall = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const { ElementPicker } = await import('@controllers/ElementPicker')
+    const lastCall = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     const onClickCallback = lastCall?.[1]
 
@@ -474,9 +474,9 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
     })
 
     // STEP 2: Click on target element A to make it the new root
-    const { ElementInteractionController } = await import('@controllers/ElementInteractionController')
-    let lastCall = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const { ElementPicker } = await import('@controllers/ElementPicker')
+    let lastCall = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     let onClickCallback = lastCall?.[1]
 
@@ -515,8 +515,8 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
     })
 
     // STEP 4: Click on target element B (different element) to make it the new root
-    lastCall = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    lastCall = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     onClickCallback = lastCall?.[1]
 
@@ -599,9 +599,9 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
       toggleButton.click()
     })
 
-    const { ElementInteractionController } = await import('@controllers/ElementInteractionController')
-    const lastCall = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const { ElementPicker } = await import('@controllers/ElementPicker')
+    const lastCall = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     const onClickCallback = lastCall?.[1]
 
@@ -632,8 +632,8 @@ describe('RuioContextProvider - Element Reselection Outline Application', () => 
       expect(screen.getByTestId('selection-mode-active').textContent).toBe('true')
     })
 
-    const lastCall2 = vi.mocked(ElementInteractionController).mock.calls[
-      vi.mocked(ElementInteractionController).mock.calls.length - 1
+    const lastCall2 = vi.mocked(ElementPicker).mock.calls[
+      vi.mocked(ElementPicker).mock.calls.length - 1
     ]
     const onClickCallback2 = lastCall2?.[1]
 

--- a/test/context/RuioContextProvider.rootDetection.test.tsx
+++ b/test/context/RuioContextProvider.rootDetection.test.tsx
@@ -13,8 +13,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn(() => vi.fn()),
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn(() => vi.fn()),
 }))
 
 // Test component to access context values

--- a/test/context/RuioContextProvider.test.tsx
+++ b/test/context/RuioContextProvider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, act } from '@testing-library/react'
 import { RuioContextProvider, useRuioContext } from '@context/RuioContextProvider'
 import { applyCommittedOutlines } from '@utils/outline'
-import { ElementInteractionController } from '@controllers/ElementInteractionController'
+import { ElementPicker } from '@controllers/ElementPicker'
 import userEvent from '@testing-library/user-event'
 import { waitFor } from '@testing-library/react'
 import { describe, test, expect, beforeEach, vi, Mock } from 'vitest'
@@ -15,11 +15,11 @@ vi.mock('@utils/outline', async () => {
     resetCommittedOutlines: vi.fn(),
   }
 })
-vi.mock('@controllers/ElementInteractionController')
+vi.mock('@controllers/ElementPicker')
 
 // mocks target
-const mockedElementInteractionController = ElementInteractionController as Mock<
-  typeof ElementInteractionController
+const mockedElementPicker = ElementPicker as Mock<
+  typeof ElementPicker
 >
 const mockedApplyBorders = applyCommittedOutlines as Mock<typeof applyCommittedOutlines>
 
@@ -30,8 +30,8 @@ const TestComponent = () => {
     depth,
     setDepth,
     maxDepth,
-    isElementSelectionModeActive,
-    setIsElementSelectionModeActive,
+    isElementPickerActive,
+    setIsElementPickerActive,
     rootElement,
   } = useRuioContext()
 
@@ -44,7 +44,7 @@ const TestComponent = () => {
       <button
         data-testid="select-element-mode"
         onClick={() => {
-          setIsElementSelectionModeActive(!isElementSelectionModeActive)
+          setIsElementPickerActive(!isElementPickerActive)
         }}
       >
         Select Element Mode
@@ -112,7 +112,7 @@ describe('RuioContextProvider', () => {
   test('should call cleanup function when selection mode is triggered', async () => {
     const cleanupMock = vi.fn()
 
-    mockedElementInteractionController.mockReturnValue(cleanupMock)
+    mockedElementPicker.mockReturnValue(cleanupMock)
 
     render(
       <RuioContextProvider>

--- a/test/controllers/ElementPicker.test.tsx
+++ b/test/controllers/ElementPicker.test.tsx
@@ -1,7 +1,7 @@
-import { ElementInteractionController } from '@controllers/ElementInteractionController'
+import { ElementPicker } from '@controllers/ElementPicker'
 import { describe, it, test, expect, beforeEach, afterEach, vi } from 'vitest'
 
-describe('ElementInteractionController', () => {
+describe('ElementPicker', () => {
   let mockHoverCallback: ReturnType<typeof vi.fn>
   let mockClickCallback: ReturnType<typeof vi.fn>
   let rootElement: HTMLElement
@@ -24,7 +24,7 @@ describe('ElementInteractionController', () => {
     mockHoverCallback = vi.fn()
     mockClickCallback = vi.fn()
 
-    cleanup = ElementInteractionController(mockHoverCallback, mockClickCallback)
+    cleanup = ElementPicker(mockHoverCallback, mockClickCallback)
   })
 
   afterEach(() => {
@@ -40,7 +40,7 @@ describe('ElementInteractionController', () => {
    */
   test('runs without errors when called with a valid callback', () => {
     expect(() => {
-      ElementInteractionController(mockHoverCallback, mockClickCallback)
+      ElementPicker(mockHoverCallback, mockClickCallback)
     }).not.toThrow()
   })
 

--- a/test/controllers/RuioToggleController.test.tsx
+++ b/test/controllers/RuioToggleController.test.tsx
@@ -15,8 +15,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn(() => vi.fn()),
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn(() => vi.fn()),
 }))
 
 describe('RuioToggleController - Visual Regression', () => {

--- a/test/examples/examples.test.tsx
+++ b/test/examples/examples.test.tsx
@@ -16,8 +16,8 @@ vi.mock('@utils/outline', async () => {
   }
 })
 
-vi.mock('@controllers/ElementInteractionController', () => ({
-  ElementInteractionController: vi.fn(() => vi.fn()),
+vi.mock('@controllers/ElementPicker', () => ({
+  ElementPicker: vi.fn(() => vi.fn()),
 }))
 
 describe('Example Applications', () => {

--- a/test/hooks/useElementPicker.test.tsx
+++ b/test/hooks/useElementPicker.test.tsx
@@ -1,28 +1,28 @@
 import { renderHook, act } from '@testing-library/react'
-import { useElementSelection } from '@hooks/useElementSelection'
-import { ElementInteractionController } from '@controllers/ElementInteractionController'
+import { useElementPicker } from '@hooks/useElementPicker'
+import { ElementPicker } from '@controllers/ElementPicker'
 import { applyCommittedOutlines } from '@utils/outline'
 import { describe, test, expect, beforeEach, vi, Mock } from 'vitest'
 
-vi.mock('@controllers/ElementInteractionController')
+vi.mock('@controllers/ElementPicker')
 vi.mock('@utils/outline')
 
-describe('useElementSelection', () => {
-  const mockOnElementSelected = vi.fn()
+describe('useElementPicker', () => {
+  const mockOnElementPicked = vi.fn()
   const mockCleanup = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(ElementInteractionController as Mock).mockReturnValue(mockCleanup)
+    ;(ElementPicker as Mock).mockReturnValue(mockCleanup)
   })
 
   test('initializes with isActive false', () => {
     const { result } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: false,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
@@ -31,11 +31,11 @@ describe('useElementSelection', () => {
 
   test('toggle function changes isActive state', () => {
     const { result } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: false,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
@@ -54,37 +54,37 @@ describe('useElementSelection', () => {
 
   test('does not initialize controller when ruioEnabled is false', () => {
     renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: false,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
-    expect(ElementInteractionController).not.toHaveBeenCalled()
+    expect(ElementPicker).not.toHaveBeenCalled()
   })
 
   test('does not initialize controller when isActive is false', () => {
     renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: true,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
-    expect(ElementInteractionController).not.toHaveBeenCalled()
+    expect(ElementPicker).not.toHaveBeenCalled()
   })
 
   test('initializes controller when both ruioEnabled and isActive are true', () => {
     const { result } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: true,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
@@ -92,16 +92,16 @@ describe('useElementSelection', () => {
       result.current.setIsActive(true)
     })
 
-    expect(ElementInteractionController).toHaveBeenCalled()
+    expect(ElementPicker).toHaveBeenCalled()
   })
 
   test('calls cleanup when hook unmounts', () => {
     const { result, unmount } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: true,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
@@ -109,7 +109,7 @@ describe('useElementSelection', () => {
       result.current.setIsActive(true)
     })
 
-    expect(ElementInteractionController).toHaveBeenCalled()
+    expect(ElementPicker).toHaveBeenCalled()
 
     unmount()
 
@@ -118,11 +118,11 @@ describe('useElementSelection', () => {
 
   test('calls cleanup when isActive changes to false', () => {
     const { result } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: true,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 
@@ -130,7 +130,7 @@ describe('useElementSelection', () => {
       result.current.setIsActive(true)
     })
 
-    expect(ElementInteractionController).toHaveBeenCalled()
+    expect(ElementPicker).toHaveBeenCalled()
     mockCleanup.mockClear()
 
     act(() => {
@@ -142,11 +142,11 @@ describe('useElementSelection', () => {
 
   test('toggle function maintains referential equality', () => {
     const { result, rerender } = renderHook(() =>
-      useElementSelection({
+      useElementPicker({
         ruioEnabled: true,
         depth: 3,
         currentColorPalette: 'dynamic',
-        onElementSelected: mockOnElementSelected,
+        onElementPicked: mockOnElementPicked,
       }),
     )
 


### PR DESCRIPTION
tl;dr all the variations of element selection specific logic (elementInteraction, elementSelect, etc.) have been normalized and simplified to contain elementPicker instead. 